### PR TITLE
Add a toolbar to the application

### DIFF
--- a/src/petab_gui/views/main_view.py
+++ b/src/petab_gui/views/main_view.py
@@ -121,6 +121,7 @@ class MainWindow(QMainWindow):
     def setup_toolbar(self):
         # add a toolbar with actions from self.task_bar
         tb = self.addToolBar("MainToolbar")
+        self.setUnifiedTitleAndToolBarOnMac(True)
 
         # first the normal open / save operations
         tb.addAction(self.task_bar.file_menu.upload_yaml_action)

--- a/src/petab_gui/views/main_view.py
+++ b/src/petab_gui/views/main_view.py
@@ -115,6 +115,21 @@ class MainWindow(QMainWindow):
 
         self.tab_widget.currentChanged.connect(self.set_docks_visible)
 
+        self.setup_toolbar()
+
+    
+    def setup_toolbar(self):
+        # add a toolbar with actions from self.task_bar
+        tb = self.addToolBar("MainToolbar")
+
+        # first the normal open / save operations
+        tb.addAction(self.task_bar.file_menu.upload_yaml_action)
+        tb.addAction(self.task_bar.file_menu.save_action)
+                
+        # then actions like validation / upload matrix
+
+
+
     def add_menu_action(self, dock_widget, name):
         """Helper function to add actions to the menu for showing dock widgets"""
         action = self.view_menu.addAction(name)

--- a/src/petab_gui/views/task_bar.py
+++ b/src/petab_gui/views/task_bar.py
@@ -1,4 +1,4 @@
-from PySide6.QtWidgets import QMenu
+from PySide6.QtWidgets import QMenu, QStyle
 from PySide6.QtGui import QAction
 
 
@@ -48,6 +48,9 @@ class FileMenu(BasicMenu):
         self.upload_yaml_action = self.add_action_or_menu(
             "Upload YAML Configuration"
         )
+        self.upload_yaml_action.setIcon(self.parent.style().standardIcon(
+            QStyle.SP_DialogOpenButton
+        ))
         self.upload_table_menu = self.add_action_or_menu(
             "Upload Tables or SBML", is_action=False
         )
@@ -70,6 +73,9 @@ class FileMenu(BasicMenu):
 
         # self.open_action = self.add_action("Open")  # Currently no Function?
         self.save_action = self.add_action_or_menu("Save")
+        self.save_action.setIcon(self.parent.style().standardIcon(
+            QStyle.SP_DialogSaveButton
+        ))
         self.menu.addSeparator()
         self.exit_action = self.add_action_or_menu("Close")
 


### PR DESCRIPTION
So ideally, we would have a toolbar with actions from the main menu. Currently some things are odd with it: 

- when the actions are initially created, they should have been created with icons / shortcuts 

since that didn't happen, the toolbar right now has really long names. 

I suggest, that we separate creating actions from adding them to menu / toolbars / controllers as discussed earlier today. 