### PR TITLE
 - create sbmlmodel from string

### DIFF
--- a/src/petab_gui/models/petab_model.py
+++ b/src/petab_gui/models/petab_model.py
@@ -100,7 +100,7 @@ class PEtabModel:
         directory: str
             The directory to save the PEtab model to.
         """
-        self.problem.to_files(prefix_path=directory)
+        self.current_petab_problem.to_files_generic(prefix_path=directory)
 
     @property
     def current_petab_problem(self) -> petab.Problem:

--- a/src/petab_gui/models/sbml_model.py
+++ b/src/petab_gui/models/sbml_model.py
@@ -2,6 +2,7 @@ from PySide6.QtCore import QObject, Signal
 import libsbml
 import tempfile
 from petab.v1.models.sbml_model import SbmlModel
+from petab.v1.sbml import load_sbml_from_string
 import petab.v1 as petab
 from ..utils import sbmlToAntimony, antimonyToSBML
 
@@ -42,8 +43,16 @@ class SbmlViewerModel(QObject):
         """Temporary write SBML to file and turn into petab.models.Model."""
         if self.sbml_text == "":
             return None
-        with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp:
-            tmp.write(self.sbml_text)
-            tmp_path = tmp.name
-            sbml_model = SbmlModel.from_file(tmp_path)
-        return sbml_model
+        
+        sbml_reader, sbml_document, sbml_model = load_sbml_from_string(
+            self.sbml_text
+        )
+
+        model_id = sbml_model.getIdAttribute()
+
+        return SbmlModel(
+            sbml_model=sbml_model,
+            sbml_reader=sbml_reader,
+            sbml_document=sbml_document,
+            model_id=model_id,
+        )


### PR DESCRIPTION
this PR fixes the issue of getting the current sbml model. 

Unfortunately warnings are interpreted as an error, would need latest libpetab from develop to work properly. 