### PR TITLE
Fixing Delegates

### DIFF
--- a/src/petab_gui/C.py
+++ b/src/petab_gui/C.py
@@ -1,48 +1,42 @@
 """Constants for the PEtab edit GUI."""
-# Measurement Columns
-MEASUREMENT_COLUMNS = {
-    "observableId": "STRING",
-    "preequilibrationConditionId": "STRING",
-    "simulationConditionId": "STRING",
-    "measurement": "NUMERIC",
-    "time": "NUMERIC",
-    "observableParameters": "STRING",
-    "noiseParameters": "STRING",
-    "datasetId": "STRING",
-    "replicateId": "STRING"
-}
-
-# Observable Columns
-OBSERVABLE_COLUMNS = {
-    "observableId": "STRING",
-    "observableName": "STRING",  # optional
-    "observableFormula": "STRING",
-    "observableTransformation": "STRING",  # optional
-    "noiseFormula": "STRING",
-    "noiseDistribution": "STRING"  # optional
-}
-
-# Parameter Columns
-PARAMETER_COLUMNS = {
-    "parameterId": "STRING",
-    "parameterName": "STRING",  # optional
-    "parameterScale": "STRING",
-    "lowerBound": "NUMERIC",
-    "upperBound": "NUMERIC",
-    "nominalValue": "NUMERIC",
-    "estimate": "BOOLEAN",
-    "initializationPriorType": "STRING",  # optional
-    "initializationPriorParameters": "STRING",  # optional
-    "objectivePriorType": "STRING",  # optional
-    "objectivePriorParameters": "STRING"  # optional
-}
-
-# Condition Columns
-CONDITION_COLUMNS = {
-    "conditionId": "STRING",
-    "conditionName": "STRING"  # optional
-    # Additional columns representing different parameters and their values under varying conditions can be added as needed.
-}
+COLUMNS = {
+    "measurement": {
+        "observableId": {"type": "STRING", "optional": False},
+        "preequilibrationConditionId": {"type": "STRING", "optional": True},
+        "simulationConditionId": {"type": "STRING", "optional": False},
+        "time": {"type": "NUMERIC", "optional": False},
+        "measurement": {"type": "NUMERIC", "optional": False},
+        "observableParameters": {"type": "STRING", "optional": True},
+        "noiseParameters": {"type": "STRING", "optional": True},
+        "datasetId": {"type": "STRING", "optional": True},
+        "replicateId": {"type": "STRING", "optional": True},
+    },
+    "observable": {
+        "observableId": {"type": "STRING", "optional": False},
+        "observableName": {"type": "STRING", "optional": True},
+        "observableFormula": {"type": "STRING", "optional": False},
+        "observableTransformation": {"type": "STRING", "optional": True},
+        "noiseFormula": {"type": "STRING", "optional": False},
+        "noiseDistribution": {"type": "STRING", "optional": True},
+    },
+    "parameter": {
+        "parameterId": {"type": "STRING", "optional": False},
+        "parameterName": {"type": "STRING", "optional": True},
+        "parameterScale": {"type": "STRING", "optional": False},
+        "lowerBound": {"type": "NUMERIC", "optional": False},
+        "upperBound": {"type": "NUMERIC", "optional": False},
+        "nominalValue": {"type": "NUMERIC", "optional": False},
+        "estimate": {"type": "STRING", "optional": False},
+        "initializationPriorType": {"type": "STRING", "optional": True},
+        "initializationPriorParameters": {"type": "STRING", "optional": True},
+        "objectivePriorType": {"type": "STRING", "optional": True},
+        "objectivePriorParameters": {"type": "STRING", "optional": True},
+    },
+    "condition": {
+        "conditionId": {"type": "STRING", "optional": False},
+        "conditionName": {"type": "STRING", "optional": True},
+    }
+    }
 
 CONFIG = {
     'window_title': 'My Application',

--- a/src/petab_gui/controllers/mother_controller.py
+++ b/src/petab_gui/controllers/mother_controller.py
@@ -171,6 +171,13 @@ class MainController:
     def setup_actions(self):
         """Setup actions for the main controller."""
         actions = {}
+        # New File
+        actions["new"] = QAction(
+            qta.icon("mdi6.file-document"),
+            "New", self.view
+        )
+        actions["new"].setShortcut("Ctrl+N")
+        actions["new"].triggered.connect(self.new_file)
         # Open YAML
         actions["open_yaml"] = QAction(
             qta.icon("mdi6.folder-open"),
@@ -393,7 +400,6 @@ class MainController:
         elif file_path.endswith((".xml", ".sbml")):
             self.sbml_controller.open_and_overwrite_sbml(file_path)
 
-
     def open_yaml_and_load_files(self, yaml_path=None):
         """Upload files from a YAML configuration.
 
@@ -437,20 +443,39 @@ class MainController:
                 "All files uploaded successfully from the YAML configuration.",
                 color="green"
             )
-            # rerun the completers
-            for controller in [
-                self.measurement_controller,
-                self.observable_controller,
-                self.parameter_controller,
-                self.condition_controller
-            ]:
-                controller.setup_completers()
+            # # rerun the completers
+            # for controller in [
+            #     self.measurement_controller,
+            #     self.observable_controller,
+            #     self.parameter_controller,
+            #     self.condition_controller
+            # ]:
+            #     controller.setup_completers()
             self.unsaved_changes = False
 
         except Exception as e:
             self.logger.log_message(
                 f"Failed to upload files from YAML: {str(e)}", color="red"
             )
+
+    def new_file(self):
+        """Empty all tables. In case of unsaved changes, ask to save."""
+        if self.unsaved_changes:
+            reply = QMessageBox.question(
+                self.view, "Unsaved Changes",
+                "You have unsaved changes. Do you want to save them?",
+                QMessageBox.Save | QMessageBox.Discard | QMessageBox.Cancel,
+                QMessageBox.Save
+            )
+            if reply == QMessageBox.Save:
+                self.save_model()
+        for controller in [
+            self.measurement_controller,
+            self.observable_controller,
+            self.parameter_controller,
+            self.condition_controller
+        ]:
+            controller.clear_table()
 
     def check_model(self):
         """Check the consistency of the model. And log the results."""

--- a/src/petab_gui/controllers/mother_controller.py
+++ b/src/petab_gui/controllers/mother_controller.py
@@ -70,6 +70,13 @@ class MainController:
             self.logger,
             self
         )
+        self.controllers = [
+            self.measurement_controller,
+            self.observable_controller,
+            self.parameter_controller,
+            self.condition_controller,
+            self.sbml_controller
+        ]
         # Checkbox states for Find + Replace
         self.petab_checkbox_states = {
             "measurement": False,
@@ -416,6 +423,8 @@ class MainController:
         if not yaml_path:
             return
         try:
+            for controller in self.controllers:
+                controller.release_completers()
             # Load the YAML content
             with open(yaml_path, 'r') as file:
                 yaml_content = yaml.safe_load(file)
@@ -443,14 +452,9 @@ class MainController:
                 "All files uploaded successfully from the YAML configuration.",
                 color="green"
             )
-            # # rerun the completers
-            # for controller in [
-            #     self.measurement_controller,
-            #     self.observable_controller,
-            #     self.parameter_controller,
-            #     self.condition_controller
-            # ]:
-            #     controller.setup_completers()
+            # rerun the completers
+            for controller in self.controllers:
+                controller.setup_completers()
             self.unsaved_changes = False
 
         except Exception as e:

--- a/src/petab_gui/controllers/table_controllers.py
+++ b/src/petab_gui/controllers/table_controllers.py
@@ -147,6 +147,10 @@ class TableController(QObject):
         )
         self.overwritten_df.emit()
 
+    def clear_table(self):
+        """Clear the table."""
+        self.model.clear_table()
+
     def delete_row(self):
         """Delete the selected row(s) from the table."""
         table_view = self.view.table_view

--- a/src/petab_gui/controllers/table_controllers.py
+++ b/src/petab_gui/controllers/table_controllers.py
@@ -51,6 +51,15 @@ class TableController(QObject):
     def setup_completers(self):
         pass
 
+    def release_completers(self):
+        """Sets the completers to None. Safety Measure."""
+        if not self.completers:
+            return
+        for column_index in range(self.model.columnCount()):
+            self.view.table_view.setItemDelegateForColumn(column_index, None)
+        self.completers = {}
+        print("Completers released.")
+
     def setup_connections_specific(self):
         """Will be implemented in child controllers."""
         pass

--- a/src/petab_gui/utils.py
+++ b/src/petab_gui/utils.py
@@ -520,12 +520,11 @@ class SignalForwarder(QObject):
 
 
 def create_empty_dataframe(column_dict: dict, table_type: str):
-    columns = list(column_dict.keys())
+    columns = [col for col, props in column_dict.items() if not props["optional"]]
     dtypes = {
-        col: 'object' if dtype == "STRING"
-        else 'float64' if dtype == "NUMERIC"
-        else 'bool'
-        for col, dtype in column_dict.items()
+        col: 'float64' if props["type"] == "NUMERIC"
+        else 'object'
+        for col, props in column_dict.items() if not props["optional"]
     }
     df = pd.DataFrame(columns=columns).astype(dtypes)
     # set potential index columns

--- a/src/petab_gui/views/main_view.py
+++ b/src/petab_gui/views/main_view.py
@@ -143,6 +143,7 @@ class MainWindow(QMainWindow):
         self.setUnifiedTitleAndToolBarOnMac(True)
 
         # first the normal open / save operations
+        tb.addAction(actions["new"])
         tb.addAction(actions["open_yaml"])
         tb.addAction(actions["save"])
         tb.addAction(actions["check_petab"])


### PR DESCRIPTION
1. Columns have been indicated as necessary or optional
2. Columns Can be added as one likes
3. Item Delegates are now correctly deleted and reinstated

Potential Issue:
- Right now the Item Delegates are only initialized at the very start or when overwriting. If we think about the `starting from scratch` cases, adding a new column should probably also add a delegate. Any idea of a elegant solutions? My crude one would be when adding a column it checks whether this is one that can use a item delegate and then initiates it.