### PR TITLE
Empty Condition DF to have at least one column

### DIFF
--- a/src/petab_gui/C.py
+++ b/src/petab_gui/C.py
@@ -34,7 +34,7 @@ COLUMNS = {
     },
     "condition": {
         "conditionId": {"type": "STRING", "optional": False},
-        "conditionName": {"type": "STRING", "optional": True},
+        "conditionName": {"type": "STRING", "optional": False},
     }
     }
 


### PR DESCRIPTION
Changed the default columns in condition to have at least on column (plus conditionId index). Fixes bug mentioned in #55