### PR TITLE
Disallow Tabs in docks

### DIFF
--- a/src/petab_gui/views/main_view.py
+++ b/src/petab_gui/views/main_view.py
@@ -108,7 +108,7 @@ class MainWindow(QMainWindow):
 
         # Allow docking in multiple areas
         self.data_tab.setDockOptions(
-            QMainWindow.AllowNestedDocks | QMainWindow.AllowTabbedDocks
+            QMainWindow.AllowNestedDocks
         )
 
         self.tab_widget.currentChanged.connect(self.set_docks_visible)


### PR DESCRIPTION
Dont allow tabbing docks anymore, fixes invisibility problems. Fixes a bug where tabs vanished and could not be brought back anymore