### PR TITLE
Correct exit of Help-Mode

### DIFF
--- a/src/petab_gui/controllers/utils.py
+++ b/src/petab_gui/controllers/utils.py
@@ -42,9 +42,7 @@ class _WhatsThisClickHelp(QObject):
 
     def _exit_mode(self):
         """Uncheck action and remove filter."""
-        self.action.blockSignals(True)
         self.action.setChecked(False)
-        self.action.blockSignals(False)
         app = QApplication.instance()
         if app:
             app.removeEventFilter(self)


### PR DESCRIPTION
Fixed a bug that had the help-mode cursor not be reset. I blocked signals there.