### PR TITLE
Fix SetuptoolsDeprecationWarning / update license info

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,13 +24,11 @@ dependencies = [
     "copasi-basico",
     "copasi-petab-importer"
 ]
-
-[project.license]
-file = "LICENSE"
+license-files = ["LICENSE"]
 
 [build-system]
 requires = [
-    "setuptools>=42",
+    "setuptools>=77.0.0",
     "wheel",
     "pyside6",
     "pandas",


### PR DESCRIPTION
Fixes:
```
SetuptoolsDeprecationWarning: `project.license` as a TOML table is deprecated
!!

        ********************************************************************************
        Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).

        By 2026-Feb-18, you need to update your project and remove deprecated calls
        or your builds will no longer be supported.

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
```